### PR TITLE
Add new option: skip-image-in-html

### DIFF
--- a/src/cli/builders/documentOptionBuilder.ts
+++ b/src/cli/builders/documentOptionBuilder.ts
@@ -15,6 +15,11 @@ export default function documentOptionBuilder<T>(args: Argv<T>) {
       type: 'array',
       default: [CE_OUTPUT_COMPONENT.TABLE, CE_OUTPUT_COMPONENT.ER],
     })
+    .option('skip-image-in-html', {
+      describe: 'skip image file attachment in html document',
+      type: 'boolean',
+      default: false,
+    })
     .option('format', {
       describe: 'output format of generated documents',
       choices: [CE_OUTPUT_FORMAT.HTML, CE_OUTPUT_FORMAT.MARKDOWN, CE_OUTPUT_FORMAT.PDF, CE_OUTPUT_FORMAT.IMAGE],

--- a/src/cli/commands/buildDocumentCommandHandler.ts
+++ b/src/cli/commands/buildDocumentCommandHandler.ts
@@ -97,10 +97,12 @@ export default async function buildDocumentCommandHandler(option: IBuildCommandO
         theme: CE_MERMAID_THEME.DARK,
       };
       const documents = await createHtml(option, renderData);
-      const imageDocument = await createImageHtml(imageOption, renderData);
-
-      await writeToImage(imageDocument, imageOption, renderData);
       await Promise.all(documents.map((document) => fs.promises.writeFile(document.filename, document.content)));
+
+      if (!option.skipImageInHtml) {
+        const imageDocument = await createImageHtml(imageOption, renderData);
+        await writeToImage(imageDocument, imageOption, renderData);
+      }
 
       return documents.map((document) => document.filename);
     }

--- a/src/configs/interfaces/IDocumentOption.ts
+++ b/src/configs/interfaces/IDocumentOption.ts
@@ -22,6 +22,9 @@ export default interface IDocumentOption extends ICommonOption {
   /** erdia entity database file path */
   databasePath?: string;
 
+  /** skip image file attachment in html document */
+  skipImageInHtml?: boolean;
+
   /** document version using package.json version or timestamp */
   versionFrom: 'timestamp' | 'package.json' | 'file';
 

--- a/src/creators/createImageHtml.ts
+++ b/src/creators/createImageHtml.ts
@@ -13,7 +13,10 @@ export default async function createImageHtml(
   option: IBuildCommandOption,
   renderData: AsyncReturnType<typeof getRenderData>,
 ): Promise<IErdiaDocument> {
-  const rawHtml = await evaluateTemplate(CE_TEMPLATE_NAME.IMAGE_DOCUMENT, renderData);
+  const rawHtml = await evaluateTemplate(CE_TEMPLATE_NAME.IMAGE_DOCUMENT, {
+    ...renderData,
+    option: { ...renderData.option, width: '200vw' },
+  });
   const prettiedHtml = await applyPrettier(rawHtml, 'html');
   const outputDir = await getDirname(option.output ?? process.cwd());
   const tempFileName = path.join(outputDir, `${randomUUID()}.html`);

--- a/src/template/config/init-command.ts
+++ b/src/template/config/init-command.ts
@@ -40,6 +40,9 @@ const build = `{
   // - image
   "format": "<%= it.config.format %>",
 
+  // skip image file attachment in html document
+  "skipImageInHtml": false,
+
   // mermaid.js plugin theme configuration
   // @url https://mermaid-js.github.io/mermaid/#/Setup?id=theme
   "theme": "<%= it.config.theme %>",

--- a/src/template/defaultTemplates.ts
+++ b/src/template/defaultTemplates.ts
@@ -1,4 +1,4 @@
-import buildConfig from '#template/config/build-command';
+import buildConfig from '#template/config/init-command';
 import { CE_TEMPLATE_NAME } from '#template/cosnt-enum/CE_TEMPLATE_NAME';
 import htmlDocument from '#template/html/document';
 import htmlToC from '#template/html/document-toc';

--- a/src/template/html/mermaid.ts
+++ b/src/template/html/mermaid.ts
@@ -63,16 +63,11 @@ const mermaid = `<!DOCTYPE html>
       <% }) -%>
       </pre>
 
+      <% if (!it.option.skipImageInHtml) { %>
       <h3 class="title is-4">
         <a class="anchor-link" href="/<%= it.metadata.name %>.svg" target="_blank" aria-label="Link to this section: Entity Relationship Diagram Image">Image</a>
       </h3>
-    </section>
-
-    <section>
-      <h2 id="entity-relationship-mermiad-diagram" class="title is-3">
-        ER Diagram Link
-        <a class="anchor-link" href="/<%= it.metadata.name %>.svg" aria-label="Link to this section: Entity Relationship Diagram">#</a>
-      </h2>
+      <% } %>
     </section>
 
     <div class="mx-auto p-2" style="width: 100%;"></div>


### PR DESCRIPTION
- add new option: skip-image-in-html
  - skip image attachment in html document
  - some of alpine linux not support puppeteer, in this case this option help to skip image attachment