### PR TITLE
Change command: `template` > `eject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Why `erdia` ?
 Summary,
 
 1. ER diagram create using [mermaid.js](http://mermaid.js.org/) syntax.
-1. Every document create using ETA template engine
-1. Only need TypeORM configuration
+1. Every document create using [ETA](https://eta.js.org/) template engine
+1. Use [TypeORM](https://typeorm.io/)
 
 Automate your database ER diagram drawing!
 
@@ -69,20 +69,20 @@ D-->H[image]
 
 installation
 
-```basn
+```bash
 npm i erdia --save-dev
 ```
 
 initialization
 
-```basn
+```bash
 npx erdia init
 ```
 
 ## Usage
 
 ```sh
-erdia build -d [your dataSource path] -o dbdoc --format html
+erdia build -d [your dataSource path] -o dist/entity --format html
 ```
 
 ## Requirement
@@ -106,7 +106,7 @@ erdia build -d [your dataSource path] -o dbdoc --format html
 
 ```sh
 # PDF document generate
-erdia build -d [your dataSourcePath] -o db.pdf --format pdf
+erdia build -d [your dataSourcePath] -o dist/entity --format pdf
 ```
 
 ## Template
@@ -114,7 +114,7 @@ erdia build -d [your dataSourcePath] -o db.pdf --format pdf
 `erdia` use ETA template for entity specification document and ER diagram. Template easily detach from erdia.
 
 ```bash
-npx erdia template
+npx erdia eject
 ```
 
 Detached template can change and every document customizable. The template can be found [here](https://github.com/imjuni/erdia/tree/master/src/template).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import outputOptionBuilder from '#cli/builders/outputOptionBuilder';
 import buildDocumentCommandHandler from '#cli/commands/buildDocumentCommandHandler';
 import cleanDocumentCommandHandler from '#cli/commands/cleanDocumentCommandHandler';
 import initConfigCommandHandler from '#cli/commands/initConfigCommandHandler';
-import templateDetachCommandHandler from '#cli/commands/templateDetachCommandHandler';
+import templateEjectCommandHandler from '#cli/commands/templateEjectCommandHandler';
 import { CE_COMMAND_LIST } from '#configs/const-enum/CE_COMMAND_LIST';
 import type IBuildCommandOption from '#configs/interfaces/IBuildCommandOption';
 import type ICommonOption from '#configs/interfaces/ICommonOption';
@@ -20,7 +20,7 @@ sourceMapSupport.install();
 const buildCmdModule: CommandModule<IBuildCommandOption, IBuildCommandOption> = {
   command: CE_COMMAND_LIST.BUILD,
   aliases: CE_COMMAND_LIST.BUILD_ALIAS,
-  describe: 'build entity, er diagram document',
+  describe: 'generate an entity specification document and ER diagram document',
   builder: (argv) => {
     const withCommonArgv = commonOptionBuilder<IBuildCommandOption>(argv);
     const withDocumentArgv = documentOptionBuilder<IBuildCommandOption>(withCommonArgv);
@@ -40,7 +40,7 @@ const buildCmdModule: CommandModule<IBuildCommandOption, IBuildCommandOption> = 
 const cleanCmdModule: CommandModule<ICommonOption, ICommonOption> = {
   command: CE_COMMAND_LIST.CLEAN,
   aliases: CE_COMMAND_LIST.CLEAN_ALIAS,
-  describe: 'clean entity, er diagram document',
+  describe: 'clean generated document',
   builder: (argv) => {
     const withCommonArgv = commonOptionBuilder<ICommonOption>(argv);
     return withCommonArgv;
@@ -58,7 +58,7 @@ const cleanCmdModule: CommandModule<ICommonOption, ICommonOption> = {
 const initCmdModule: CommandModule<{}, {}> = {
   command: CE_COMMAND_LIST.INIT,
   aliases: CE_COMMAND_LIST.INIT_ALIAS,
-  describe: 'create `.erdiarc` configuration',
+  describe: 'generate configuration file: `.erdiarc`',
   handler: async () => {
     try {
       await initConfigCommandHandler();
@@ -69,18 +69,17 @@ const initCmdModule: CommandModule<{}, {}> = {
   },
 };
 
-const templateCmdModule: CommandModule<Pick<ICommonOption, 'output'>, Pick<ICommonOption, 'output'>> = {
-  command: CE_COMMAND_LIST.TEMPLATE,
-  aliases: CE_COMMAND_LIST.TEMPLATE_ALIAS,
-  describe: 'detach template file',
+const ejectCmdModule: CommandModule<Pick<ICommonOption, 'output'>, Pick<ICommonOption, 'output'>> = {
+  command: CE_COMMAND_LIST.EJECT,
+  aliases: CE_COMMAND_LIST.EJECT_ALIAS,
+  describe: 'eject document template files',
   builder: (argv) => {
     const withCommonArgv = outputOptionBuilder<Pick<ICommonOption, 'output'>>(argv);
     return withCommonArgv;
   },
   handler: async (argv) => {
     try {
-      consola.info('template command');
-      await templateDetachCommandHandler(argv);
+      await templateEjectCommandHandler(argv);
     } catch (caught) {
       const err = isError(caught, new Error('unknown error raised'));
       consola.error(err);
@@ -94,7 +93,7 @@ parser
   .command(buildCmdModule as CommandModule<{}, IBuildCommandOption>)
   .command(cleanCmdModule as CommandModule<{}, ICommonOption>)
   .command(initCmdModule as CommandModule<{}, ICommonOption>)
-  .command(templateCmdModule as CommandModule<{}, ICommonOption>)
+  .command(ejectCmdModule as CommandModule<{}, ICommonOption>)
   .demandCommand()
   .recommendCommands()
   .config(preLoadConfig())

--- a/src/cli/builders/buildOptionBuilder.ts
+++ b/src/cli/builders/buildOptionBuilder.ts
@@ -4,42 +4,43 @@ export default function buildOptionBuilder<T>(args: Argv<T>) {
   // option
   args
     .option('prettier-config', {
-      describe: 'prettier configuration file path',
+      describe: 'define the path to the prettier configuration file',
       type: 'string',
       default: undefined,
     })
     .option('title', {
-      describe: 'title tag content that inside of html document',
+      describe: 'define what will be written in the HTML document title tag',
       type: 'string',
       default: undefined,
     })
     .option('width', {
-      describe: 'ER diagram width, it will be set width css attribute',
+      describe: 'define the ER diagram width. The width is defined by the HTML document css attribute width',
       type: 'string',
       default: '100%',
     })
     .option('viewport-width', {
-      describe: 'puppeteer viewport width',
+      describe: 'define the viewport width to puppeteer. The width is defined by the HTML document css attribute width',
       type: 'number',
       default: 1280,
     })
     .option('viewport-height', {
-      describe: 'puppeteer viewport height',
+      describe:
+        'define the viewport height to puppeteer. The width is defined by the HTML document css attribute height',
       type: 'number',
       default: 720 * 2,
     })
     .option('puppeteer-config-path', {
-      describe: 'puppeteer config file path',
+      describe: 'define the path to puppeteer config file',
       type: 'string',
     })
     .option('image-format', {
-      describe: 'puppeteer config file path',
+      describe: 'define the format to image file',
       type: 'string',
       choices: ['svg', 'png'],
       default: 'svg',
     })
     .option('background-color', {
-      describe: "Background color. Example: transparent, red, '#F0F0F0'. Optional. Default: white",
+      describe: "define the background color to html documents. eg. transparent, red, '#F0F0F0'",
       type: 'string',
       default: 'white',
     });

--- a/src/cli/builders/commonOptionBuilder.ts
+++ b/src/cli/builders/commonOptionBuilder.ts
@@ -6,12 +6,12 @@ export default function commonOptionBuilder<T>(args: Argv<T>) {
   outputOptionBuilder(args)
     .option('config', {
       alias: 'c',
-      describe: 'file path of configuration',
+      describe: 'define the path to to configuration file: .erdiarc',
       type: 'string',
     })
     .option('data-source-path', {
       alias: 'd',
-      describe: 'dataSource file path',
+      describe: 'define the path to TypeORM data source file',
       type: 'string',
     })
     .demandOption('data-source-path');

--- a/src/cli/builders/documentOptionBuilder.ts
+++ b/src/cli/builders/documentOptionBuilder.ts
@@ -10,30 +10,31 @@ export default function documentOptionBuilder<T>(args: Argv<T>) {
   args
     .option('components', {
       alias: 't',
-      describe: 'output components of result type',
+      describe: 'define the output component to builded documents',
       choices: [CE_OUTPUT_COMPONENT.TABLE, CE_OUTPUT_COMPONENT.ER],
       type: 'array',
       default: [CE_OUTPUT_COMPONENT.TABLE, CE_OUTPUT_COMPONENT.ER],
     })
     .option('skip-image-in-html', {
-      describe: 'skip image file attachment in html document',
+      describe: 'enabling the this option will skip attaching the ER diagram image file to the html document',
       type: 'boolean',
       default: false,
     })
     .option('format', {
-      describe: 'output format of generated documents',
+      describe: 'define the output format to builded documents',
       choices: [CE_OUTPUT_FORMAT.HTML, CE_OUTPUT_FORMAT.MARKDOWN, CE_OUTPUT_FORMAT.PDF, CE_OUTPUT_FORMAT.IMAGE],
       type: 'string',
       default: CE_OUTPUT_FORMAT.HTML,
     })
     .option('project-name', {
-      describe: 'determine whether project name will come from the name in `package.json` or database name',
+      describe: 'define whether project name will come from the `package.json` name field or database name',
       type: 'string',
       choices: [CE_PROJECT_NAME_FROM.APPLICATION, CE_PROJECT_NAME_FROM.DATABASE],
       default: CE_PROJECT_NAME_FROM.APPLICATION,
     })
     .option('version-from', {
-      describe: 'document version using package.json version or timestamp',
+      describe:
+        'define whether document version will come from the `package.json` version field or specific file, timestamp',
       choices: [CE_ENTITY_VERSION_FROM.PACKAGE_JSON, CE_ENTITY_VERSION_FROM.FILE, CE_ENTITY_VERSION_FROM.TIMESTAMP],
       type: 'string',
       default: CE_ENTITY_VERSION_FROM.PACKAGE_JSON,
@@ -44,11 +45,11 @@ export default function documentOptionBuilder<T>(args: Argv<T>) {
       default: undefined,
     })
     .option('template-path', {
-      describe: 'template file path',
+      describe: 'define the directory to ETA templates',
       type: 'string',
     })
     .option('theme', {
-      describe: 'mermaid.js plugin theme configuration. see https://mermaid-js.github.io/mermaid/#/Setup?id=theme',
+      describe: 'define whether mermaid.js plugin theme. see https://mermaid-js.github.io/mermaid/#/Setup?id=theme',
       choices: [
         CE_MERMAID_THEME.DEFAULT,
         CE_MERMAID_THEME.DARK,

--- a/src/cli/builders/outputOptionBuilder.ts
+++ b/src/cli/builders/outputOptionBuilder.ts
@@ -4,7 +4,7 @@ export default function outputOptionBuilder<T>(args: Argv<T>) {
   // option
   args.option('output', {
     alias: 'o',
-    describe: 'output file name',
+    describe: 'define the directory to output file',
     type: 'string',
   });
 

--- a/src/cli/commands/templateEjectCommandHandler.ts
+++ b/src/cli/commands/templateEjectCommandHandler.ts
@@ -3,14 +3,17 @@ import getCwd from '#configs/modules/getCwd';
 import { CE_TEMPLATE_NAME } from '#template/cosnt-enum/CE_TEMPLATE_NAME';
 import defaultTemplates from '#template/defaultTemplates';
 import getOutputDirectory from '#tools/files/getOutputDirectory';
+import consola from 'consola';
 import fs from 'fs';
 import { isFalse } from 'my-easy-fp';
 import { exists, getDirname } from 'my-node-fp';
 import path from 'path';
 
-export default async function templateDetachCommandHandler(option: Pick<ICommonOption, 'output'>) {
+export default async function templateEjectCommandHandler(option: Pick<ICommonOption, 'output'>) {
   const outputDir = await getOutputDirectory(option, getCwd(process.env));
   const templateDir = path.join(outputDir, 'template');
+
+  consola.info('Output directory: ', templateDir);
 
   const writeFile = async (template: CE_TEMPLATE_NAME) => {
     const filename = path.resolve(path.join(templateDir, `${template}.eta`));
@@ -49,6 +52,8 @@ export default async function templateDetachCommandHandler(option: Pick<ICommonO
       CE_TEMPLATE_NAME.PDF_TABLE,
     ].map((template) => writeFile(template)),
   );
+
+  consola.success('eject success: ', templateDir);
 
   return templateDir;
 }

--- a/src/configs/const-enum/CE_COMMAND_LIST.ts
+++ b/src/configs/const-enum/CE_COMMAND_LIST.ts
@@ -2,12 +2,12 @@ export const CE_COMMAND_LIST = {
   BUILD: 'build',
   INIT: 'init',
   CLEAN: 'clean',
-  TEMPLATE: 'template',
+  EJECT: 'eject',
 
   BUILD_ALIAS: 'b',
   INIT_ALIAS: 'i',
   CLEAN_ALIAS: 'c',
-  TEMPLATE_ALIAS: 't',
+  EJECT_ALIAS: 'e',
 } as const;
 
 export type CE_COMMAND_LIST = (typeof CE_COMMAND_LIST)[keyof typeof CE_COMMAND_LIST];

--- a/src/configs/modules/getConfigContent.ts
+++ b/src/configs/modules/getConfigContent.ts
@@ -1,4 +1,4 @@
-import templateDetachCommandHandler from '#cli/commands/templateDetachCommandHandler';
+import templateEjectCommandHandler from '#cli/commands/templateEjectCommandHandler';
 import { CE_DEFAULT_VALUE } from '#configs/const-enum/CE_DEFAULT_VALUE';
 import { CE_ENTITY_VERSION_FROM } from '#configs/const-enum/CE_ENTITY_VERSION_FROM';
 import { CE_IMAGE_FORMAT } from '#configs/const-enum/CE_IMAGE_FORMAT';
@@ -6,6 +6,8 @@ import { CE_MERMAID_THEME } from '#configs/const-enum/CE_MERMAID_THEME';
 import { CE_OUTPUT_COMPONENT } from '#configs/const-enum/CE_OUTPUT_COMPONENT';
 import { CE_OUTPUT_FORMAT } from '#configs/const-enum/CE_OUTPUT_FORMAT';
 import type { IInitDocAnswer } from '#configs/interfaces/InquirerAnswer';
+import getAutoCompleteSource from '#configs/modules/getAutoCompleteSource';
+import getCwd from '#configs/modules/getCwd';
 import { CE_TEMPLATE_NAME } from '#template/cosnt-enum/CE_TEMPLATE_NAME';
 import evaluateTemplate from '#template/evaluateTemplate';
 import Fuse from 'fuse.js';
@@ -13,8 +15,6 @@ import globby from 'globby';
 import inquirer from 'inquirer';
 import inquirerPrompt from 'inquirer-autocomplete-prompt';
 import path from 'path';
-import getAutoCompleteSource from './getAutoCompleteSource';
-import getCwd from './getCwd';
 
 export default async function getConfigContent() {
   /**
@@ -202,7 +202,7 @@ export default async function getConfigContent() {
   ]);
 
   const templateDir = await (answer.isDetachTemplate
-    ? templateDetachCommandHandler({ output: getCwd(process.env) })
+    ? templateEjectCommandHandler({ output: getCwd(process.env) })
     : Promise.resolve(undefined));
 
   const file = await evaluateTemplate(CE_TEMPLATE_NAME.CONFIG_JSON, {

--- a/src/template/html/style.ts
+++ b/src/template/html/style.ts
@@ -51,6 +51,10 @@ const style = `<style>
 
     /* Layout */
     @media (min-width: 1200px) {
+      html {
+        scroll-padding-top: 4rem;
+      }
+
       body {
         display: grid;
         grid-template-rows: auto;

--- a/src/template/loadTemplates.ts
+++ b/src/template/loadTemplates.ts
@@ -1,12 +1,16 @@
 import type IDocumentOption from '#configs/interfaces/IDocumentOption';
-import { CE_TEMPLATE_NAME } from '#template/cosnt-enum/CE_TEMPLATE_NAME';
 import defaultTemplates from '#template/defaultTemplates';
 import fs from 'fs';
+import globby from 'globby';
 import { isTrue } from 'my-easy-fp';
 import { exists } from 'my-node-fp';
 import path from 'path';
 
 const templates: Record<string, string> = { ...defaultTemplates };
+
+export function getTemplate(template: string) {
+  return templates[template];
+}
 
 export function getTemplates() {
   return templates;
@@ -19,39 +23,72 @@ export async function loadTemplates(option: Pick<IDocumentOption, 'templatePath'
     return true;
   }
 
-  await Promise.all(
-    [
-      CE_TEMPLATE_NAME.HTML_DOCUMENT_TOC,
-      CE_TEMPLATE_NAME.HTML_DOCUMENT,
-      CE_TEMPLATE_NAME.HTML_MERMAID_SCRIPT,
-      CE_TEMPLATE_NAME.HTML_MERMAID_TOC,
-      CE_TEMPLATE_NAME.HTML_MERMAID,
-      CE_TEMPLATE_NAME.HTML_STYLE,
-      CE_TEMPLATE_NAME.HTML_TABLE,
-      CE_TEMPLATE_NAME.IMAGE_DOCUMENT,
-      CE_TEMPLATE_NAME.IMAGE_MERMAID_SCRIPT,
-      CE_TEMPLATE_NAME.IMAGE_STYLE,
-      CE_TEMPLATE_NAME.MARKDOWN_DOCUMENT,
-      CE_TEMPLATE_NAME.MARKDOWN_MERMAID,
-      CE_TEMPLATE_NAME.MARKDOWN_TABLE,
-      CE_TEMPLATE_NAME.MARKDOWN_TOC,
-      CE_TEMPLATE_NAME.MERMAID_DOCUMENT,
-      CE_TEMPLATE_NAME.MERMAID_ENTITY,
-      CE_TEMPLATE_NAME.MERMAID_RELATION,
-      CE_TEMPLATE_NAME.PDF_DOCUMENT_TOC,
-      CE_TEMPLATE_NAME.PDF_DOCUMENT,
-      CE_TEMPLATE_NAME.PDF_MERMAID_SCRIPT,
-      CE_TEMPLATE_NAME.PDF_STYLE,
-      CE_TEMPLATE_NAME.PDF_TABLE,
-    ].map(async (template) => {
-      const filename = path.resolve(path.join(templatePath, `${template}.eta`));
+  const resolvedTemplateFilePath = path.resolve(templatePath);
+  const [htmlTemplateFiles, markdownTemplateFiles, imageTemplateFiles, pdfTemplateFiles, mermaidTemplateFiles] =
+    await Promise.all([
+      globby(['**/*'], {
+        cwd: path.join(resolvedTemplateFilePath, 'html'),
+        onlyFiles: true,
+        gitignore: true,
+        dot: true,
+      }),
 
-      if (isTrue(await exists(filename))) {
-        const buf = await fs.promises.readFile(filename);
-        templates[template] = buf.toString();
-      }
-    }),
-  );
+      globby(['**/*'], {
+        cwd: path.join(resolvedTemplateFilePath, 'markdown'),
+        onlyFiles: true,
+        gitignore: true,
+        dot: true,
+      }),
+
+      globby(['**/*'], {
+        cwd: path.join(resolvedTemplateFilePath, 'image'),
+        onlyFiles: true,
+        gitignore: true,
+        dot: true,
+      }),
+
+      globby(['**/*'], {
+        cwd: path.join(resolvedTemplateFilePath, 'pdf'),
+        onlyFiles: true,
+        gitignore: true,
+        dot: true,
+      }),
+
+      globby(['**/*'], {
+        cwd: path.join(resolvedTemplateFilePath, 'mermaid'),
+        onlyFiles: true,
+        gitignore: true,
+        dot: true,
+      }),
+    ]);
+
+  const templateFiles = [
+    htmlTemplateFiles.map((filePath) => path.join(resolvedTemplateFilePath, 'html', filePath)),
+    markdownTemplateFiles.map((filePath) => path.join(resolvedTemplateFilePath, 'markdown', filePath)),
+    imageTemplateFiles.map((filePath) => path.join(resolvedTemplateFilePath, 'image', filePath)),
+    pdfTemplateFiles.map((filePath) => path.join(resolvedTemplateFilePath, 'pdf', filePath)),
+    mermaidTemplateFiles.map((filePath) => path.join(resolvedTemplateFilePath, 'mermaid', filePath)),
+  ].flat();
+
+  const loadedTemplateFiles = (
+    await Promise.all(
+      templateFiles.map(async (templateFilePath) => {
+        if (isTrue(await exists(templateFilePath))) {
+          const buf = await fs.promises.readFile(templateFilePath);
+          const relative = path.relative(resolvedTemplateFilePath, templateFilePath).replace(`.${path.sep}`, '');
+          templates[relative] = buf.toString();
+
+          return { key: relative, content: buf.toString() };
+        }
+
+        return undefined;
+      }),
+    )
+  ).filter((template): template is { key: string; content: string } => template != null);
+
+  loadedTemplateFiles.forEach((templateFile) => {
+    templates[templateFile.key] = templateFile.content;
+  });
 
   return true;
 }

--- a/src/template/pdf/style.ts
+++ b/src/template/pdf/style.ts
@@ -1,6 +1,10 @@
 const style = `<style>
     /* Layout */
     @media (min-width: 1200px) {
+      html {
+        scroll-padding-top: 4rem;
+      }
+      
       body {
         display: grid;
         grid-template-rows: auto;

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,11 @@
+{
+  "entryPoints": [
+    "src"
+  ],
+  "tsconfig": "tsconfig.json",
+  "entryPointStrategy": "expand",
+  "exclude": [
+    "src/**/__tests__/*"
+  ],
+  "readme": "none"
+}


### PR DESCRIPTION
- change command: `template` > `eject`:  command to be more in line with its purpose and action
- fix scrolling: fixed an issue where, after creating an HTML document, going to a document link would scroll too far up and make the linked content can't viewing
- enhance template: enhance template filenames to be freely configurable except for entry points
- enhance command line option description
- enhance `README.md` contents